### PR TITLE
Add API server. Part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You can keep track of all changes on the [release page](https://github.com/daswe
 ## TODO
 - [x] Batch generation via console
 - [x] Possibility to use inference import through code
+- [ ] Add an API server
 
 ## Installation
 
@@ -47,12 +48,12 @@ pip install torch==2.1.1+cu118 torchaudio==2.1.1+cu118 --index-url https://downl
 ## Usage
 
 ```bash
-python -m rvc_python [-h] -i INPUT or -d INPUT_DIR -mp MODEL [-pi PITCH]
+python -m rvc_python [-h] -a or -i INPUT or -d INPUT_DIR -mp MODEL [-pi PITCH]
                      [-ip INDEX] [-me METHOD] [-v VERSION]
                      [-o OUTPUT] [-ir INDEX_RATE]
                      [-d DEVICE]  [-fr FILTER_RADIUS]
                      [-rsr RESAMPLE_SR]
-                     [-rmr RMS_MIX_RATE][-pr PROTECT]
+                     [-rmr RMS_MIX_RATE][-pr PROTECT] [-p PORT] [-l]
 ```
 
 ### Options
@@ -68,6 +69,9 @@ python -m rvc_python [-h] -i INPUT or -d INPUT_DIR -mp MODEL [-pi PITCH]
 
 - `-mp MODEL`, `--model MODEL` (mandatory):
     Path to model file.
+
+- `-a`, `--api`:
+     Start an API server
 
 The following options are optional:
 
@@ -105,7 +109,11 @@ The following options are optional:
 - `-pr PROTECT `, `--protect PROTECT`:
       Protects voiceless consonants and breath sounds from artifacts such as tearing in electronic music. Decrease value for increased protection but may affect indexing accuracy.
 
+- `-p PORT`, `--port PORT`:
+      Port number for the API server (default: 5050)
 
+- `-l`, `--listen`:
+      Listen to external connections
 
 ### Example Command via console
 
@@ -167,6 +175,27 @@ results = infer_files(
 print(f"Inference completed for batch processing. Check the '{results}' directory for output files.")
 ```
 
+### API Example
+
+#### POST /rvc_convert
+
+Convert a single file encoded with base64 using the model specified in the `model_path` parameter.
+
+```python
+import requests
+import base64
+
+url = "http://127.0.0.1:5050/rvc_convert"
+data = {
+    "audio_data": base64.b64encode(open("path/to/file.wav", "rb").read()).decode(),
+    "model_path": "path/to/model.pth"
+}
+
+response = requests.post(url, json=data)
+
+with open("output.wav", "wb") as f:
+    f.write(response.content)
+```
 
 ### Demo
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ fairseq==0.12.2
 faiss-cpu==1.7.3
 av
 loguru
+uvicorn
+fastapi
+pydantic

--- a/rvc_python/__main__.py
+++ b/rvc_python/__main__.py
@@ -9,6 +9,7 @@ parser = ArgumentParser(description="RVC inference")
 # Create a mutually exclusive group for input - only one of them can be provided
 input_group = parser.add_mutually_exclusive_group(required=True)
 input_group.add_argument("-i", "--input", type=str, help="Path to input file")
+input_group.add_argument("-a","--api", action="store_true", help="Start an API server")
 input_group.add_argument("-d", "--dir", type=str, help="Directory path containing audio files")
 
 parser.add_argument("-pi","--pitch", default=0, type=int, help="Transpose (integer, number of semitones)")
@@ -23,6 +24,8 @@ parser.add_argument("-fr","--filter_radius", type=int, default=3, help="Apply me
 parser.add_argument("-rsr","--resample_sr", type=int, default=0, help="Resample rate for the output audio")
 parser.add_argument("-rmr","--rms_mix_rate", type=float,default=0.25 ,help="Volume envelope mix rate")
 parser.add_argument("-pr",'--protect' ,type=float,default=0.33 ,help='Protect voiceless consonants and breath sounds')
+parser.add_argument("-p","--port", type=int, default=5050, help="Port number for the API server")
+parser.add_argument("-l","--listen", action="store_true", help="Listen to external connections")
 
 args = parser.parse_args()
 
@@ -59,3 +62,6 @@ elif args.dir:
         protect=args.protect,
         version=args.version
     )
+elif args.api:
+    import api
+    api.start_server(port=args.port, listen=args.listen)

--- a/rvc_python/api.py
+++ b/rvc_python/api.py
@@ -1,0 +1,82 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
+from loguru import logger
+from pydantic import BaseModel
+import uvicorn
+import tempfile
+import base64
+
+from infer import infer_file
+
+app = FastAPI()
+
+# Add CORS middleware 
+origins = ["*"]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class ConvertAudioRequest(BaseModel):
+    model_path: str
+    audio_data: str
+    index_path: str = ""
+    device: str = "cpu:0"
+    f0method: str = "harvest"
+    f0up_key: float = 0
+    index_rate: float = 0.5
+    filter_radius: float = 3
+    resample_sr: float = 0
+    rms_mix_rate: float = 1
+    protect: float = 0.33
+    version: str = "v2"
+
+def start_server(port: int = 5050, listen: bool = False):
+    """Start the API server"""
+    host_ip = "0.0.0.0" if listen else "127.0.0.1"
+    uvicorn.run(app, host=host_ip, port=port)
+
+@app.post("/rvc_convert")
+def rvc_convert(request: ConvertAudioRequest):
+    tmp_input = tempfile.NamedTemporaryFile(delete=True, suffix=".wav")
+    tmp_output = tempfile.NamedTemporaryFile(delete=True, suffix=".wav")
+    try:
+        logger.info("Received request to convert audio")
+        audio_data = base64.b64decode(request.audio_data)
+        tmp_input.write(audio_data)
+        input_path = tmp_input.name
+        output_path = tmp_output.name
+
+        infer_file(
+            input_path=input_path,
+            opt_path=output_path,
+            model_path=request.model_path,
+            device=request.device,
+            f0method=request.f0method,
+            index_path=request.index_path,
+            f0up_key=request.f0up_key,
+            index_rate=request.index_rate,
+            filter_radius=request.filter_radius,
+            resample_sr=request.resample_sr,
+            rms_mix_rate=request.rms_mix_rate,
+            protect=request.protect,
+            version=request.version
+        )
+
+        # Read all bytes from the output file
+        output_data = tmp_output.read()
+
+        return Response(content=output_data, media_type="audio/wav")
+    except Exception as e:
+        logger.error(e)
+        raise HTTPException(status_code=500, detail=f"An error occurred: {str(e)}")
+    finally:
+        tmp_input.close()
+        tmp_output.close()
+
+if __name__ == "__main__":
+    start_server()


### PR DESCRIPTION
Since ST Extras are deprecated and the only thing that is left without replacement is RVC, I began searching for potential alternatives. I wasn't able to find any RVC API servers that aren't Gradio which is painful to work with. So I propose to build one here.

This PR adds an initial setup of a FastAPI server that performs a voice conversion using already established inference methods.

While technically working in the current state, it still misses some parts to become a usable replacement to a now deprecated ST Extras project.

Namely, the parts that are missing:

- Model management (list/upload) = the most critical.
- Compatibility layer with the ST Extras server to use as a drop-in replacement = potentially not even needed if the extension is updated.

@daswer123 if you like this idea and overall direction, please contact me so we could discuss some details.

Related: https://github.com/SillyTavern/SillyTavern/issues/2646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an API server for audio conversion with new command-line options.
	- Added endpoint `/rvc_convert` for converting audio files through POST requests.
- **Documentation**
	- Updated README to include instructions for new API server functionality and usage examples.
- **Chores**
	- Added dependencies for web development: `uvicorn`, `fastapi`, and `pydantic`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->