### PR TITLE
Fix tempfile usage on Windows

### DIFF
--- a/rvc_python/api.py
+++ b/rvc_python/api.py
@@ -18,8 +18,8 @@ class SetParamsRequest(BaseModel):
 def setup_routes(app: FastAPI):
     @app.post("/convert")
     def rvc_convert(request: ConvertAudioRequest):
-        tmp_input = tempfile.NamedTemporaryFile(delete=True, suffix=".wav")
-        tmp_output = tempfile.NamedTemporaryFile(delete=True, suffix=".wav")
+        tmp_input = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+        tmp_output = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
         try:
             logger.info("Received request to convert audio")
             audio_data = base64.b64decode(request.audio_data)
@@ -37,6 +37,8 @@ def setup_routes(app: FastAPI):
         finally:
             tmp_input.close()
             tmp_output.close()
+            os.unlink(tmp_input.name)
+            os.unlink(tmp_output.name)
 
     @app.get("/models")
     def list_models():


### PR DESCRIPTION
Turns out a file created by tempfile can't be reopened again if you're on Windows. I previously only tested on Mac, so didn't notice until I tried it on another machine. The solution is to delete the file manually on exit.

Reference: https://stackoverflow.com/a/54768241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved temporary file management by requiring explicit deletion of temporary audio files, enhancing resource control.
  
- **New Features**
	- Updated the `rvc_convert` function to provide better management of temporary files, reducing potential file system clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->