### PR TITLE
Add ability to override models_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ You can add new models by:
 
 ### Model Options
 - `-mp`, `--model`: Path to the RVC model file
+- `-md`, `--models_dir`: Directory containing RVC models (default: `rvc_models` in the current directory)
 - `-ip`, `--index`: Path to the index file (optional)
 - `-v`, `--version`: Model version (v1 or v2)
 

--- a/rvc_python/__main__.py
+++ b/rvc_python/__main__.py
@@ -25,6 +25,7 @@ def main():
     # Common arguments for both CLI and API
     for subparser in [cli_parser, api_parser]:
         subparser.add_argument("-mp", "--model", type=str, required=True, help="Path to model file")
+        subparser.add_argument("-md", "--models_dir", type=str, default="rvc_models", help="Directory to store models")
         subparser.add_argument("-ip", "--index", type=str, default="", help="Path to index file (optional)")
         subparser.add_argument("-de", "--device", type=str, default="cpu:0", help="Device to use (e.g., cpu:0, cuda:0)")
         subparser.add_argument("-me", "--method", type=str, default="rmvpe", choices=['harvest', "crepe", "rmvpe", 'pm'], help="Pitch extraction algorithm")
@@ -39,7 +40,7 @@ def main():
     args = parser.parse_args()
 
     # Initialize RVCInference
-    rvc = RVCInference(device=args.device)
+    rvc = RVCInference(models_dir=args.models_dir, device=args.device)
     rvc.load_model(args.model)
     rvc.set_params(
         f0method=args.method,


### PR DESCRIPTION
Adds an argparser variable for models_dir. The default is `rvc_models` as before, but is overridable now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option `--models_dir` for specifying the directory of RVC models, enhancing configurability and usability.
	- Default directory for models is now set to `rvc_models`, allowing for more flexible model management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->