### PR TITLE
Fix OutputContainer usage

### DIFF
--- a/rvc_python/lib/audio.py
+++ b/rvc_python/lib/audio.py
@@ -38,7 +38,7 @@ def audio2(i, o, format, sr):
     if format == "f32le":
         format = "pcm_f32le"
 
-    ostream = out.add_stream(format, channels=1)
+    ostream = out.add_stream(format)
     ostream.sample_rate = sr
 
     for frame in inp.decode(audio=0):


### PR DESCRIPTION
I don't know where it originally comes from, but OutputContainer in PyAV doesn't have a `channels` attribute (and never had), so trying to set it while loading audio causes an error.

```
2024-09-16 17:58:30.444 | INFO     | rvc_python.api:rvc_convert:33 - Received request to convert audio
2024-09-16 17:58:30 | WARNING | rvc_python.modules.vc.modules | Traceback (most recent call last):
  File "D:\SillyTavern\TTS\rvc-python\rvc_python\lib\audio.py", line 63, in load_audio
    audio2(f, out, "f32le", sr)
  File "D:\SillyTavern\TTS\rvc-python\rvc_python\lib\audio.py", line 41, in audio2
    ostream = out.add_stream(format, channels=1)
  File "av\\container\\output.pyx", line 132, in av.container.output.OutputContainer.add_stream
  File "av\\stream.pyx", line 111, in av.stream.Stream.__setattr__
AttributeError: attribute 'channels' of 'av.audio.codeccontext.AudioCodecContext' objects is not writable
```

Documentation source: https://pyav.org/docs/9.0.2/api/container.html#av.container.OutputContainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in audio handling by allowing the configuration of audio channels without a hardcoded specification.

- **Bug Fixes**
	- Improved compatibility with various audio formats and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->