### PR TITLE
fix: `add_stream` to use `'mono'` instead

### DIFF
--- a/rvc_python/lib/audio.py
+++ b/rvc_python/lib/audio.py
@@ -38,7 +38,7 @@ def audio2(i, o, format, sr):
     if format == "f32le":
         format = "pcm_f32le"
 
-    ostream = out.add_stream(format, channels=1)
+    ostream = out.add_stream(format, layout='mono')
     ostream.sample_rate = sr
 
     for frame in inp.decode(audio=0):


### PR DESCRIPTION
`layout='mono'` reduces `AttributeError`s

Should fix the error in this comment: https://github.com/daswer123/rvc-python/issues/13#issuecomment-2346416895